### PR TITLE
Allow `verify_ssl` as an option

### DIFF
--- a/arista-eapi.gemspec
+++ b/arista-eapi.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 0"
 
-  spec.add_dependency "rest-client", '~> 1.6'
-  spec.add_dependency 'json', '~> 1.8'
+  spec.add_runtime_dependency "rest-client", '~> 1.7', '>= 1.7.2'
+  spec.add_runtime_dependency 'json', '~> 1.8', '>= 1.8.1'
 end

--- a/lib/arista/eapi/request.rb
+++ b/lib/arista/eapi/request.rb
@@ -12,20 +12,27 @@ module Arista
       end
 
       def payload
-        @payload ||= JSON.generate({
-          :jsonrpc => '2.0',
-          :method  => 'runCmds',
-          :id      => 1,
-          :params  => {
-            :version => 1,
-            :cmds    => commands,
-            :format  => options[:format]
-          },
-        })
+        @payload ||= JSON.generate(
+          jsonrpc: '2.0',
+          method: 'runCmds',
+          id: 1,
+          params: {
+            version: 1,
+            cmds: commands,
+            format: options[:format]
+          }
+        )
       end
 
       def execute
-        Arista::EAPI::Response.new(commands, RestClient.post(switch.url, payload))
+        req = RestClient::Request.execute(
+          method: :get,
+          url: switch.url,
+          timeout: 10,
+          verify_ssl: switch.verify_ssl,
+          payload: payload
+        )
+        Arista::EAPI::Response.new(commands, req)
       end
     end
   end

--- a/lib/arista/eapi/switch.rb
+++ b/lib/arista/eapi/switch.rb
@@ -1,14 +1,15 @@
 module Arista
   module EAPI
     class Switch
-      attr_accessor :hostname, :user, :password, :protocol, :url, :attributes
+      attr_accessor :hostname, :user, :password, :protocol, :url, :attributes, :verify_ssl
 
-      def initialize(hostname, user, password, protocol = 'https')
+      def initialize(hostname, user, password, protocol = 'https', verify_ssl = true)
         self.attributes = {}
         self.hostname = hostname
         self.user = user
         self.password = password
         self.protocol = protocol
+        self.verify_ssl = verify_ssl
 
         userpass = [ CGI.escape(user), CGI.escape(password) ].join(':')
         self.url = "#{protocol}://#{userpass}@#{hostname}/command-api"

--- a/lib/arista/eapi/version.rb
+++ b/lib/arista/eapi/version.rb
@@ -1,5 +1,5 @@
 module Arista
   module EAPI
-    VERSION = "0.11.6"
+    VERSION = "0.11.7"
   end
 end


### PR DESCRIPTION
**Allow `verify_ssl` as an option**
This is to allow clients to specific the details of ssl verification via
arista-eapi.

Also minor syntax fixed up using Ruby 1.9's hash syntax.
